### PR TITLE
Provided null default for $slug

### DIFF
--- a/src/Middleware/IdentifyModule.php
+++ b/src/Middleware/IdentifyModule.php
@@ -29,7 +29,7 @@ class IdentifyModule
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next, $slug)
+    public function handle($request, Closure $next, $slug = null)
     {
         $request->session()->put('module', $this->module->where('slug', $slug)->first());
 


### PR DESCRIPTION
In instances where you use this middleware on a route group, it will fail on the few URLs that don't contain the slug.  This resolves that issue.
